### PR TITLE
bitstreams by bundle search and uuid general search

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,16 +13,19 @@ use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\DeleteBundleControlle
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\DeleteCollectionController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\DeleteCommunityController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\DeleteItemController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetBitstreamsByBundleUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetBundlesByItemController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetBundlesByItemUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionByHandleController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionByNameController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionByUUIDController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionsByCommunityController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionsByCommunityUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionsController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesIsParentController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesWhereParentController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesWhereParentByUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByHandleController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByNameController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByUUIDController;
@@ -30,6 +33,7 @@ use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemByHandleContro
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemByNameController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemByUUIDController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsByCollectionController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsByCollectionUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\UpdateCollectionController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\UpdateCommunityController;
@@ -50,6 +54,9 @@ Route::group(["prefix" => "communities"], function () {
         }
         if ($request->has('communityParentName')) {
             return response()->json((new GetCommunitiesWhereParentController)->handler($request->communityParentName,$request->page), 200);
+        }
+        if ($request->has('communityParentUuid')) {
+            return response()->json((new GetCommunitiesWhereParentByUuidController)->handler($request->communityParentUuid,$request->page), 200);
         }
         return response()->json((new GetCommunitiesController)->handler($request->page), 200);
     });
@@ -78,6 +85,9 @@ Route::group(["prefix" => "collections"], function () {
     Route::get("", function (Request $request) {
         if ($request->has('communityName')) {
             return response()->json((new GetCollectionsByCommunityController)->handler($request->communityName,$request->page), 200);
+        }
+        if ($request->has('communityUuid')) {
+            return response()->json((new GetCollectionsByCommunityUuidController)->handler($request->communityUuid,$request->page), 200);
         }
         if ($request->has('handle')) {
             return response()->json(((new GetCollectionByHandleController)->handler($request->handle))->toArray(), 200);
@@ -109,6 +119,9 @@ Route::group(["prefix" => "items"], function () {
     Route::get("", function (Request $request) {
         if ($request->has('collectionName')) {
             return response()->json((new GetItemsByCollectionController)->handler($request->collectionName,$request->page), 200);
+        }
+        if ($request->has('collectionUuid')) {
+            return response()->json((new GetItemsByCollectionUuidController)->handler($request->collectionUuid,$request->page), 200);
         }
         if ($request->has('handle')) {
             return response()->json(((new GetItemByHandleController)->handler($request->handle))->toArray(), 200);
@@ -175,10 +188,16 @@ Route::group(["prefix" => "relationships"], function () {
 
 
 Route::group(["prefix" => "bitstreams"], function () {
+    Route::get("", function (Request $request) {
+        if ($request->has('bundleUuid')) {
+            return response()->json((new GetBitstreamsByBundleUuidController())->handler($request->bundleUuid,$request->page), 200);
+        }
+        return response()->json(["message"=>"Get all bundles is unsupported, add bundleUuid param to request."], 200);
+    });
     Route::post("", function (Request $request) {
         if ($request->has('itemUuid')) {
             return response()->json(((new CreateBitstreamByItemUuidController)->handler($request->filebitstream, $request->filename, $request->contentType ,$request->itemUuid, $request->bundleName))->toArray(), 200);
         }
         return response()->json(((new CreateBitstreamController)->handler($request->filebitstream, $request->filename, $request->contentType ,$request->bundleUuid))->toArray(), 200);
-    });    
+    });
 });

--- a/src/Dspace7/Application/GetBitstreamsByBundleUseCase.php
+++ b/src/Dspace7/Application/GetBitstreamsByBundleUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Application;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\BitstreamContract;
+
+final class GetBitstreamsByBundleUseCase
+{
+    private $bitstreamContract;
+    public function __construct(
+        BitstreamContract $bitstreamContract
+    ) {
+        $this->bitstreamContract = $bitstreamContract;
+    }
+    public function handler(string $bundleUUID, int $page): array
+    {
+        return $this->bitstreamContract->findAllByBundleUUID($bundleUUID, $page);
+    }
+}

--- a/src/Dspace7/Domain/Contracts/BitstreamContract.php
+++ b/src/Dspace7/Domain/Contracts/BitstreamContract.php
@@ -8,4 +8,5 @@ use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Bitstream;
 interface BitstreamContract
 {
     public function create($filestream, $filename, $contentType, $bundleUUID) : ?Bitstream;
+    public function findAllByBundleUUID(string $bundleUUID, int $page) : array;
 }

--- a/src/Dspace7/Domain/Exceptions/BitstreamExceptions.php
+++ b/src/Dspace7/Domain/Exceptions/BitstreamExceptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions;
+
+use InvalidArgumentException;
+
+class BitstreamExceptions extends InvalidArgumentException
+{
+    public static function notFound()
+    {
+        return new static("Bitstream not found.");
+    }
+
+    public static function empty()
+    {
+        return new static("Bitstreams is empty.");
+    }
+}

--- a/src/Dspace7/Infrastructure/GetBitstreamsByBundleUuidController.php
+++ b/src/Dspace7/Infrastructure/GetBitstreamsByBundleUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetBitstreamsByBundleUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\BitstreamRequests;
+
+final class GetBitstreamsByBundleUuidController
+{
+    private $bundleRequests;
+    public function __construct()
+    {
+        $this->bundleRequests = new BitstreamRequests();
+    }
+    public function handler(string $itemUuid, ?int $page)
+    {
+        return (new GetBitstreamsByBundleUseCase($this->bundleRequests))->handler($itemUuid,($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/GetCollectionsByCommunityUuidController.php
+++ b/src/Dspace7/Infrastructure/GetCollectionsByCommunityUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetCollectionsByCommunityUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\CollectionRequests;
+
+final class GetCollectionsByCommunityUuidController
+{
+    private $collectionRequest;
+    public function __construct()
+    {
+        $this->collectionRequest = new CollectionRequests();
+    }
+    public function handler(string $communityUuid, ?int $page)
+    {
+        return (new GetCollectionsByCommunityUseCase($this->collectionRequest))->handler($communityUuid,($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/GetCommunitiesWhereParentByUuidController.php
+++ b/src/Dspace7/Infrastructure/GetCommunitiesWhereParentByUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetCommunitiesWhereParentUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\CommunityRequests;
+
+final class GetCommunitiesWhereParentByUuidController
+{
+    private $communityRequest;
+    public function __construct()
+    {
+        $this->communityRequest = new CommunityRequests();
+    }
+    public function handler(string $communityParentUuid, ?int $page)
+    {
+        return (new GetCommunitiesWhereParentUseCase($this->communityRequest))->handler($communityParentUuid, ($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/GetItemsByCollectionUuidController.php
+++ b/src/Dspace7/Infrastructure/GetItemsByCollectionUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetItemsByCollectionUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\ItemRequests;
+
+final class GetItemsByCollectionUuidController
+{
+    private $itemRequests;
+    public function __construct()
+    {
+        $this->itemRequests = new ItemRequests();
+    }
+    public function handler(string $collectionUuid, ?int $page)
+    {
+        return (new GetItemsByCollectionUseCase($this->itemRequests))->handler($collectionUuid,($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/Requests/BitstreamRequests.php
+++ b/src/Dspace7/Infrastructure/Requests/BitstreamRequests.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests;
 
 use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\BitstreamContract;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions\BitstreamExceptions;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Bitstream;
 use Epsomsegura\Laraveldspaceclient\Shared\Infrastructure\GuzzleRequester;
 
@@ -18,7 +19,7 @@ final class BitstreamRequests implements BitstreamContract
     }
 
     public function create($filestream, $filename, $contentType, $bundleUUID): ?Bitstream
-    {        
+    {
         $bitstream = $this->requester->setMethod('post')->setEndpoint('core/bundles/'.$bundleUUID.'/bitstreams')->setMultipart([
             [
                 'name' => 'file',
@@ -26,7 +27,7 @@ final class BitstreamRequests implements BitstreamContract
                 'filename' => $filename,
                 'Content-type' => $contentType
             ]
-        ])->setHeaders(null)->request();                
+        ])->setHeaders(null)->request();
         return new Bitstream(
             $bitstream->uuid,
             $bitstream->name,
@@ -37,5 +38,17 @@ final class BitstreamRequests implements BitstreamContract
             $bitstream->sequenceId,
             $bitstream->type,
         );
-    } 
+    }
+
+    public function findAllByBundleUUID(string $itemUUID, int $page) : array
+    {
+        $response = $this->requester->setMethod('get')->setEndpoint('core/bundles/'.$itemUUID.'/bitstreams')->setQuery(["page" => $page])->request();
+        if (!array_key_exists('_embedded', get_object_vars($response))) {
+            throw BitstreamExceptions::notFound();
+        }
+        $bitstreams = array_filter($response->_embedded->bitstreams, function($bitstream){
+            return ($bitstream->type === "bitstream");
+        });
+        return ["elements" => $bitstreams, "page" => $response->page];
+    }
 }

--- a/src/Dspace7/Infrastructure/Requests/ItemRequests.php
+++ b/src/Dspace7/Infrastructure/Requests/ItemRequests.php
@@ -56,11 +56,12 @@ final class ItemRequests implements ItemContract
         if ($items->_embedded->searchResult && !array_key_exists('_embedded', get_object_vars($items->_embedded->searchResult))) {
             throw ItemExceptions::notFound();
         }
+        $page = $items->_embedded->searchResult->page;
         $items = array_filter($items->_embedded->searchResult->_embedded->objects, function($item){
             $item = $item->_embedded->indexableObject;
             return ($item->type === "item");
         });
-        return $this->getItems($items);
+        return ['items' => $this->getItems($items), 'page' => $page ];
     }
     public function findOneByHandle(string $handle): ?Item
     {


### PR DESCRIPTION
Hola, 

En esta PR habilita lo siguiente:
- Se añade a la capa de dominio y a la capa de aplicación lo necesario para recuperar los bitstreams a partir de un bundle
- Se añade a la capa de infraestructura un controlador para obtener "bitstreams" a partir del UUID de un "bundle"
- Se añade a la capa de infraestructura un controlador para obtener "collections" a partir del UUID de un "community"
- Se añade a la capa de infraestructura un controlador para obtener "communities" a partir del UUID de un "community" padre
- Se añade a la capa de infraestructura un controlador para obtener "items" a partir del UUID de un "collection"
- Se añadieron las rutas a la API para los controladores previamente mencionados

Adicionalmente se ha realizado la siguiente corrección:
- Se realizo una corrección sobre la obtención de items a partir de una colección la cual no mostraba información sobre la pagina consultada (no existía una referencia a cuantas paginas había que consultar para recorrer la totalidad de items pertenecientes a la colección)