### PR TITLE
Added support for get data form resource policies and workflowitems

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,9 @@
 <?php
 
-use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBitstreamController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBitstreamByItemUuidController;
-use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBundleController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBitstreamController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBundleByItemUuidController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateBundleController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateCollectionController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateCommunityController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\CreateCommunityWithParentController;
@@ -24,8 +24,8 @@ use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionsByCommu
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCollectionsController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesIsParentController;
-use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesWhereParentController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesWhereParentByUuidController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunitiesWhereParentController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByHandleController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByNameController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetCommunityByUUIDController;
@@ -35,6 +35,9 @@ use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemByUUIDControll
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsByCollectionController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsByCollectionUuidController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetItemsController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetResourcePoliciesByBitstreamUuidController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetWorkflowitemsByCollectionUuidController;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\GetWorkflowitemByIdController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\UpdateCollectionController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\UpdateCommunityController;
 use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\UpdateItemController;
@@ -199,5 +202,34 @@ Route::group(["prefix" => "bitstreams"], function () {
             return response()->json(((new CreateBitstreamByItemUuidController)->handler($request->filebitstream, $request->filename, $request->contentType ,$request->itemUuid, $request->bundleName))->toArray(), 200);
         }
         return response()->json(((new CreateBitstreamController)->handler($request->filebitstream, $request->filename, $request->contentType ,$request->bundleUuid))->toArray(), 200);
+    });
+});
+
+
+
+
+
+Route::group(["prefix" => "resourcepolicies"], function () {
+    Route::get("", function (Request $request) {
+        if ($request->has('bitstreamUUID')) {
+            return response()->json((new GetResourcePoliciesByBitstreamUuidController())->handler($request->bitstreamUUID,$request->page), 200);
+        }
+        return response()->json(["message"=>"Get all resourcepolicies is unsupported, add bitstreamUUID param to request."], 200);
+    });
+});
+
+
+
+
+
+Route::group(["prefix" => "workflowitems"], function () {
+    Route::get("", function (Request $request) {
+        if ($request->has('collectionUuid')) {
+            return response()->json((new GetWorkflowitemsByCollectionUuidController)->handler($request->collectionUuid,$request->page), 200);
+        }
+        return response()->json(["message"=>"Get all workflowitems is unsupported, add collectionUuid param to request."], 200);
+    });
+    Route::get("{id}", function (string $id) {
+        return response()->json(((new GetWorkflowitemByIdController)->handler($id)), 200);
     });
 });

--- a/src/Dspace7/Application/GetResourcePoliciesByBitstreamUseCase.php
+++ b/src/Dspace7/Application/GetResourcePoliciesByBitstreamUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Application;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\ResourcePolicyContract;
+
+final class GetResourcePoliciesByBitstreamUseCase
+{
+    private $resourcePolicyContract;
+    public function __construct(
+        ResourcePolicyContract $resourcePolicyContract
+    ) {
+        $this->resourcePolicyContract = $resourcePolicyContract;
+    }
+    public function handler(string $bitstreamUUID, int $page): array
+    {
+        return $this->resourcePolicyContract->findAllByBitstreamUuid($bitstreamUUID, $page);
+    }
+}

--- a/src/Dspace7/Application/GetWorkflowitemByIdUseCase.php
+++ b/src/Dspace7/Application/GetWorkflowitemByIdUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Application;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\WorkflowitemContract;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Workflowitem;
+
+final class GetWorkflowitemByIdUseCase
+{
+    private $workflowitemContract;
+    public function __construct(
+        WorkflowitemContract $workflowitemContract
+    ) {
+        $this->workflowitemContract = $workflowitemContract;
+    }
+    public function handler(string $id): ?Workflowitem
+    {
+        return $this->workflowitemContract->findOneById($id);
+    }
+}

--- a/src/Dspace7/Application/GetWorkflowitemsByCollectionUseCase.php
+++ b/src/Dspace7/Application/GetWorkflowitemsByCollectionUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Application;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Collection;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\WorkflowitemContract;
+
+final class GetWorkflowitemsByCollectionUseCase
+{
+    private $workflowitemContract;
+    public function __construct(
+        WorkflowitemContract $workflowitemContract
+    ) {
+        $this->workflowitemContract = $workflowitemContract;
+    }
+    public function handler(string $collectionUUID, int $page): array
+    {
+        return $this->workflowitemContract->findAllByCollectionUUID($collectionUUID, $page);
+    }
+}

--- a/src/Dspace7/Domain/Contracts/ResourcePolicyContract.php
+++ b/src/Dspace7/Domain/Contracts/ResourcePolicyContract.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\ResourcePolicy;
+
+interface ResourcePolicyContract
+{
+    public function findAllByBitstreamUuid(string $bitstreamUUID, int $page) : array;
+}

--- a/src/Dspace7/Domain/Contracts/WorkflowitemContract.php
+++ b/src/Dspace7/Domain/Contracts/WorkflowitemContract.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Workflowitem;
+
+interface WorkflowitemContract
+{
+    public function findAllByCollectionUUID(string $collectionUUID, int $page) : array;
+    public function findOneById(string $id) : ?Workflowitem;
+}

--- a/src/Dspace7/Domain/Exceptions/ResourcePolicyExceptions.php
+++ b/src/Dspace7/Domain/Exceptions/ResourcePolicyExceptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions;
+
+use InvalidArgumentException;
+
+class ResourcePolicyExceptions extends InvalidArgumentException
+{
+    public static function notFound()
+    {
+        return new static("Resource policy not found.");
+    }
+
+    public static function empty()
+    {
+        return new static("Resource policies is empty.");
+    }
+}

--- a/src/Dspace7/Domain/Exceptions/WorkflowItemExceptions.php
+++ b/src/Dspace7/Domain/Exceptions/WorkflowItemExceptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions;
+
+use InvalidArgumentException;
+
+class WorkflowitemExceptions extends InvalidArgumentException
+{
+    public static function notFound()
+    {
+        return new static("workflowitem not found.");
+    }
+
+    public static function empty()
+    {
+        return new static("workflowitems is empty.");
+    }
+}

--- a/src/Dspace7/Domain/ResourcePolicy.php
+++ b/src/Dspace7/Domain/ResourcePolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain;
+
+class ResourcePolicy
+{
+    private int $_id;
+    private ?string $_name;
+    private ?string $_description;
+    private string $_policyType;
+    private string $_action;
+    private ?string $_startDate;
+    private ?string $_endDate;
+    private string $_type;
+    public function __construct(
+        int $id,
+        ?string $name,
+        ?string $description,
+        string $policyType,
+        string $action,
+        ?string $startDate,
+        ?string $endDate,
+        string $type,
+    ) {
+        $this->_id = $id;
+        $this->_name = $name;
+        $this->_description = $description;
+        $this->_policyType = $policyType;
+        $this->_action = $action;
+        $this->_startDate = $startDate;
+        $this->_endDate = $endDate;
+        $this->_type = $type;
+    }
+
+    public function id(): int
+    {
+        return $this->_id;
+    }
+    public function name(): ?string
+    {
+        return $this->_name;
+    }
+    public function description(): ?string
+    {
+        return $this->_description;
+    }
+    public function policyType(): string
+    {
+        return $this->_policyType;
+    }
+    public function action(): string
+    {
+        return $this->_action;
+    }
+    public function startDate(): ?string
+    {
+        return $this->_startDate;
+    }
+    public function endDate(): ?string
+    {
+        return $this->_endDate;
+    }
+    public function type(): string
+    {
+        return $this->_type;
+    }
+}

--- a/src/Dspace7/Domain/Workflowitem.php
+++ b/src/Dspace7/Domain/Workflowitem.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Domain;
+
+class Workflowitem
+{
+    private int $_id;
+    private string $_lastModified;
+    private ?string $_step;
+    private ?object $_sections;
+    private ?Item $_item;
+    private string $_type;
+    public function __construct(
+        int $id,
+        string $lastModified,
+        ?string $step,
+        ?object $sections,
+        ?Item $item,
+        string $type,
+    ) {
+        $this->_id = $id;
+        $this->_lastModified = $lastModified;
+        $this->_step = $step;
+        $this->_sections = $sections;
+        $this->_item = $item;
+        $this->_type = $type;
+    }
+
+    public function id(): int
+    {
+        return $this->_id;
+    }
+    public function lastModified(): string
+    {
+        return $this->_lastModified;
+    }
+    public function step(): ?string
+    {
+        return $this->_step;
+    }
+    public function sections(): ?object
+    {
+        return $this->_sections;
+    }
+    public function item(): ?Item
+    {
+        return $this->_item;
+    }
+    public function type(): string
+    {
+        return $this->_type;
+    }
+}

--- a/src/Dspace7/Infrastructure/GetResourcePoliciesByBitstreamUuidController.php
+++ b/src/Dspace7/Infrastructure/GetResourcePoliciesByBitstreamUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetResourcePoliciesByBitstreamUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\ResourcePolicyRequests;
+
+final class GetResourcePoliciesByBitstreamUuidController
+{
+    private $resourcePolicyRequests;
+    public function __construct()
+    {
+        $this->resourcePolicyRequests = new ResourcePolicyRequests();
+    }
+    public function handler(string $bitstreamUUID, ?int $page)
+    {
+        return (new GetResourcePoliciesByBitstreamUseCase($this->resourcePolicyRequests))->handler($bitstreamUUID,($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/GetWorkflowitemByidController.php
+++ b/src/Dspace7/Infrastructure/GetWorkflowitemByidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetWorkflowitemByIdUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\WorkflowitemRequests;
+
+final class GetWorkflowitemByIdController
+{
+    private $workflowitemRequests;
+    public function __construct()
+    {
+        $this->workflowitemRequests = new WorkflowitemRequests();
+    }
+    public function handler(string $id)
+    {
+        return (new GetWorkflowitemByIdUseCase($this->workflowitemRequests))->handler($id);
+    }
+}

--- a/src/Dspace7/Infrastructure/GetWorkflowitemsByCollectionUuidController.php
+++ b/src/Dspace7/Infrastructure/GetWorkflowitemsByCollectionUuidController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Application\GetWorkflowitemsByCollectionUseCase;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests\WorkflowitemRequests;
+
+final class GetWorkflowitemsByCollectionUuidController
+{
+    private $workflowitemRequests;
+    public function __construct()
+    {
+        $this->workflowitemRequests = new WorkflowitemRequests();
+    }
+    public function handler(string $collectionUuid, ?int $page)
+    {
+        return (new GetWorkflowitemsByCollectionUseCase($this->workflowitemRequests))->handler($collectionUuid,($page ?? 0));
+    }
+}

--- a/src/Dspace7/Infrastructure/Requests/ResourcePolicyRequests.php
+++ b/src/Dspace7/Infrastructure/Requests/ResourcePolicyRequests.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\ResourcePolicyContract;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions\ResourcePolicyExceptions;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\ResourcePolicy;
+use Epsomsegura\Laraveldspaceclient\Shared\Infrastructure\GuzzleRequester;
+
+final class ResourcePolicyRequests implements ResourcePolicyContract
+{
+    private $requester;
+
+    public function __construct()
+    {
+        $this->requester = new GuzzleRequester();
+    }
+
+    public function findAllByBitstreamUuid($bitstreamUUID, $page): array
+    {
+        $response = $this->requester->setMethod('get')->setEndpoint('authz/resourcepolicies/search/resource')->setQuery(["uuid" => $bitstreamUUID, "page" => $page])->request();
+        if (!array_key_exists('_embedded', get_object_vars($response))) {
+            throw ResourcePolicyExceptions::empty();
+        }
+        $resourcePolicies = array_filter($response->_embedded->resourcepolicies, function($resourcePolicy){
+            return ($resourcePolicy->type === "resourcepolicy");
+        });
+        return ["elements" => $resourcePolicies, "page" => $response->page];
+    }
+}

--- a/src/Dspace7/Infrastructure/Requests/WorkflowitemRequests.php
+++ b/src/Dspace7/Infrastructure/Requests/WorkflowitemRequests.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Epsomsegura\Laraveldspaceclient\Dspace7\Infrastructure\Requests;
+
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Contracts\WorkflowitemContract;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Exceptions\WorkflowitemExceptions;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Item;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Metadata;
+use Epsomsegura\Laraveldspaceclient\Dspace7\Domain\Workflowitem;
+use Epsomsegura\Laraveldspaceclient\Shared\Infrastructure\GuzzleRequester;
+
+final class WorkflowitemRequests implements WorkflowitemContract
+{
+    private $requester;
+
+    public function __construct()
+    {
+        $this->requester = new GuzzleRequester();
+    }
+
+    public function findAllByCollectionUUID(string $collectionUUID, int $page) : array
+    {
+        $items = $this->requester->setMethod('get')->setEndpoint('discover/search/objects')->setQuery(["scope"=>$collectionUUID,"page"=>$page,'dsoType'=>'xmlworkflowitem','configuration'=>'workspace'])->request();
+        if (!array_key_exists('_embedded', get_object_vars($items))) {
+            throw WorkflowitemExceptions::empty();
+        }
+        if ($items->_embedded->searchResult && !array_key_exists('_embedded', get_object_vars($items->_embedded->searchResult))) {
+            throw WorkflowitemExceptions::empty();
+        }
+        $page = $items->_embedded->searchResult->page;
+        $workflowitemobjects = array_filter($items->_embedded->searchResult->_embedded->objects, function($object){
+            $object = $object->_embedded->indexableObject;
+            return ($object->type === "workflowitem");
+        });
+        return ['workflowitems' => $this->getWorkflowitems($workflowitemobjects), 'page' => $page ];
+    }
+    public function findOneById(string $id): Workflowitem
+    {
+        $workflowitem = $this->requester->setMethod('get')->setEndpoint('workflow/workflowitems/' . $id)->request();
+        $itemobject = $workflowitem->_embedded->item;
+        $item = new Item(
+            $itemobject->id,
+            $itemobject->uuid,
+            $itemobject->name,
+            $itemobject->handle,
+            Metadata::arrayToMetadataArray(json_decode(json_encode($itemobject->metadata), TRUE)),
+            $itemobject->inArchive,
+            $itemobject->discoverable,
+            $itemobject->withdrawn,
+            $itemobject->type
+        );
+        $workflowitem = new Workflowitem(
+            $workflowitem->id,
+            $workflowitem->lastModified,
+            $workflowitem->step ?? null,
+            $workflowitem->sections,
+            $item,
+            $workflowitem->type
+        );
+        return $workflowitem;
+    }
+
+    private function getWorkflowitems(array $workflowitemobjects): array
+    {
+        $uniqueItems = [];
+        foreach ($workflowitemobjects as $workflowitemobject) {
+            $workflowitem = (is_array($workflowitemobject) ? (object)$workflowitemobject : (property_exists($workflowitemobject,"_embedded") ? $workflowitemobject->_embedded->indexableObject : $workflowitemobject));
+            $itemobject = $workflowitem->_embedded->item;
+            $item = new Item(
+                $itemobject->id,
+                $itemobject->uuid,
+                $itemobject->name,
+                $itemobject->handle,
+                Metadata::arrayToMetadataArray(json_decode(json_encode($itemobject->metadata), TRUE)),
+                $itemobject->inArchive,
+                $itemobject->discoverable,
+                $itemobject->withdrawn,
+                $itemobject->type
+            );
+            $uniqueItems[] = new Workflowitem(
+                $workflowitem->id,
+                $workflowitem->lastModified,
+                $workflowitem->step ?? null,
+                $workflowitem->sections,
+                $item,
+                $workflowitem->type
+            );
+        }
+        return $uniqueItems;
+    }
+}


### PR DESCRIPTION
Hola @epsomsegura 

Comparto contigo estos cambios realizados a la librería. Te comparto aquí la lista de cambios y funciones agregadas.

- Se agrego al dominio las entidades ResourcePolicy y Workflowitem junto con sus correspondientes contracts y Exceptions.
- Se agregaron la capa de aplicación los casos de uso para obtener las resourcePolicies a partir de un bundle, obtener los workflowitems a partir de una colección y obtener los datos de un workflowitem a partir de su ID.
- Se generaron los controladores para utilizar estos casos de uso
- Finalmente, se agregaron a las rutas disponibles del archivo web de la librería grupos de rutas para estas dos entidades y sus controladores disponibles.

Cualquier comentario estoy atento.

Saludos.